### PR TITLE
Add micro VOICE_ENGLISH & Turn off audio response when into joint calibration state via serial command 'c'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/*
 *.docx
 *.rar
 *.DS_Store

--- a/OpenCatEsp32.ino
+++ b/OpenCatEsp32.ino
@@ -16,6 +16,7 @@
 // allowed combinations: RANDOM_MIND + ULTRASONIC, RANDOM_MIND, ULTRASONIC, VOICE, CAMERA
 //  #define ULTRASONIC    //for Nybble's ultrasonic sensor. it WON‘T work with ESP32-based BiBoard directly because "AVR's 'SREG' was not declared in this scope"
 #define VOICE  // Petoi Grove voice module
+//#define VOICE_ENGLISH 1  //Force to switch to English when startup
 // #define PIR           //for PIR (Passive Infrared) sensor
 // #define DOUBLE_TOUCH  //for double touch sensor
 // #define DOUBLE_LIGHT  //for double light sensor

--- a/src/OpenCat.h
+++ b/src/OpenCat.h
@@ -503,7 +503,12 @@ void initRobot() {
 
 #ifdef VOICE
   voiceSetup();
+#if VOICE_ENGLISH
+  PTLF("Enter the English mode");
+  Serial2.println("XAa");
 #endif
+#endif
+
 #ifdef CAMERA
   cameraSetup();
 #endif
@@ -544,7 +549,6 @@ void initRobot() {
   newCmdIdx = 2;
 #endif
 #endif
-
 
   PTL("Ready!");
   idleTimer = millis();

--- a/src/reaction.h
+++ b/src/reaction.h
@@ -318,12 +318,20 @@ void reaction() {
         {
           PTLF("save offset");
           saveCalib(servoCalib);
+#ifdef VOICE
+          if (newCmdIdx == 2)
+            Serial2.println("XAc");
+#endif
           break;
         }
       case T_ABORT:
         {
           PTLF("aborted");
           i2c_eeprom_read_buffer(EEPROM_CALIB, (byte *)servoCalib, DOF);
+#ifdef VOICE
+          if (newCmdIdx == 2)
+            Serial2.println("XAc");
+#endif
           break;
         }
       case T_RESET:
@@ -386,6 +394,10 @@ void reaction() {
 #ifdef T_SERVO_MICROSECOND
                   setServoP(P_HARD);
                   hardServoQ = true;
+#endif
+#ifdef VOICE
+                  if (newCmdIdx == 2)
+                    Serial2.println("XAd");
 #endif
                   strcpy(newCmd, "calib");
                   loadBySkillName(newCmd);

--- a/src/voice.h
+++ b/src/voice.h
@@ -84,6 +84,7 @@ void read_voice() {
     PTL(raw);
     byte index = (byte)raw[2];  //interpret the 3rd byte as integer
     int shift = -1;
+    newCmdIdx = 7;
     if (index > 10 && index < 61) {
       if (index < 21) {  //11 ~ 20 are customized commands, and their indexes should be shifted by 11
         index -= 11;


### PR DESCRIPTION
- Add micro VOICE_ENGLISH to force to switch to English when startup.
- Turn off audio response when into joint calibration state via serial command 'c', and turn on after exit joint calibration state via serial command 'a' or 's'.