### PR TITLE
New feedback with simplification

### DIFF
--- a/src/OpenCat.h
+++ b/src/OpenCat.h
@@ -268,7 +268,7 @@ ServoModel_t servoModelList[] = {
 bool newBoard = false;
 
 #include <math.h>
-// token list
+// Token (T_) and Character (C_) command list
 #define T_ABORT 'a'              // abort the calibration values
 #define T_BEEP 'b'               //b note1 duration1 note2 duration2 ... e.g. b12 8 14 8 16 8 17 8 19 4 \
                          //bVolume will change the volume of the sound, in scale of 0~10. 0 will mute all sound effect. e.g. b3. \
@@ -288,17 +288,21 @@ bool newBoard = false;
 #define C_LEARN 'l'
 #define C_REPLAY 'r'
 #define T_SERVO_FOLLOW 'F'       // make the other legs follow the moved legs
+
 #define T_GYRO 'g'               // gyro-related commands. by itself, is a toggle to turn on or off the gyro function
+  // These Character (C_) commands apply to the T_GYRO Token
 #define C_GYRO_FINENESS 'F'      // increase the frequency of gyroscope sampling
 #define C_GYRO_FINENESS_OFF 'f'  // reduce the frequency of gyroscope sampling to accelerate motion
 #define C_GYRO_BALANCE 'B'       // turn on the gyro balancing
 #define C_GYRO_BALANCE_OFF 'b'   // turn off the gyro balancing
-#define C_PRINT 'P'         // always print gyro data
-#define C_PRINT_OFF 'p'     // print gyro data once then stop
+
+// These Character (C_) commands apply to various tokens that have a print capability (e.g. T_GYRO, T_SERVO_FEEDBACK)
+#define C_PRINT 'P'              // Continuously print data
+#define C_PRINT_OFF 'p'          // Print data once then stop
 
 #define T_HELP_INFO 'h'                 // hold the loop to check printed information.
-#define T_INDEXED_SIMULTANEOUS_ASC 'i'  //i jointIndex1 jointAngle1 jointIndex2 jointAngle2 ... e.g. i0 70 8 -20 9 -20 \
-                                        //a single 'i' will free the head joints if it were previously manually controlled.
+#define T_INDEXED_SIMULTANEOUS_ASC 'i'  // i jointIndex1 jointAngle1 jointIndex2 jointAngle2 ... e.g. i0 70 8 -20 9 -20 \
+                                        // a single 'i' will free the head joints if it were previously manually controlled.
 #define T_INDEXED_SIMULTANEOUS_BIN 'I'  // I jointIndex1 jointAngle1 jointIndex2 jointAngle2 ... e.g. I0 70 8 -20 9 -20
 #define T_JOINTS 'j'                    // A single "j" returns all angles. "j Index" prints the joint's angle. e.g. "j 8" or "j11".
 #define T_JOYSTICK 'J'
@@ -392,26 +396,31 @@ char terminator;
 // int serialTimeout;
 long lastSerialTime = 0;
 
-bool interruptedDuringBehavior = false;
-bool lowBatteryQ = false;
+/*  These "Q" booleans are conditions that are checked to activate or deactivate different states.  
+    A condition set to true activates (turns on) a state.
+*/
+bool lowBatteryQ = false;      // true = lowBattery() has determined that the battery voltage is below a threshold (see above VOLTAGE macros).
 bool autoLedQ = false;
 bool updateGyroQ = true;
 bool fineAdjustQ = true;
-bool gyroBalanceQ = true;
-bool printGyroQ = false;
-bool readFeedbackQ = false;
-bool followFeedbackQ = false;
-bool printFeedbackQ = false;
-bool autoSwitch = false;
+bool gyroBalanceQ = true;      // true = CONTINUOUSLY access recovery options in dealWithExceptions().
+bool printGyroQ = false;       // true = CONTINUOUSLY access print6Axis() which prints Gyro (IMU) data.
+bool readFeedbackQ = false;    // true = CONTINUOUSLY access servoFeedback() which prints servo angles.
+bool followFeedbackQ = false;  // true = CONTINUOUSLY access servoFollow() which follows servo angles as servos are manipulated and automatically calls servoFeedback() to show updated servo angles.
 bool walkingQ = false;
 bool manualHeadQ = false;
 bool nonHeadJointQ = false;
-bool workingStiffness = true;
 bool manualEyeColorQ = false;
+// bool keepDirectionQ = true;
+
+// Other booleans
+bool interruptedDuringBehavior = false;
+bool autoSwitch = false;
+bool workingStiffness = true;
 bool cameraLockI2c = false;
 bool imuLockI2c = false;
 bool gestureLockI2c = false;
-// bool keepDirectionQ = true;
+
 #define HEAD_GROUP_LEN 4  // used for controlling head pan, tilt, tail, and other joints independent from walking
 int targetHead[HEAD_GROUP_LEN];
 

--- a/src/OpenCat.h
+++ b/src/OpenCat.h
@@ -76,7 +76,7 @@
 #else
 #define BOARD "B"
 #endif
-#define DATE "250218"  // YYMMDD
+#define DATE "250219"  // YYMMDD
 String SoftwareVersion = "";
 
 #define BIRTHMARK '@'  // Send '!' token to reset the birthmark in the EEPROM so that the robot will know to restart and reset
@@ -283,6 +283,10 @@ bool newBoard = false;
                          //"d index" can turn off a single servo
 #define T_SERVO_FEEDBACK 'f'     //return the servo's position info if the chip supports feedback. \
                                         //e.g. f8 returns the 8th joint's position. A single 'f' returns all the joints' position
+#define C_FOLLOW  'F'
+#define C_FOLLOW_OFF 'f'
+#define C_LEARN 'l'
+#define C_REPLAY 'r'
 #define T_SERVO_FOLLOW 'F'       // make the other legs follow the moved legs
 #define T_GYRO 'g'               // gyro-related commands. by itself, is a toggle to turn on or off the gyro function
 #define C_GYRO_FINENESS 'F'      // increase the frequency of gyroscope sampling

--- a/src/OpenCat.h
+++ b/src/OpenCat.h
@@ -93,33 +93,31 @@ String SoftwareVersion = "";
 #define HEAD
 #define TAIL
 #define X_LEG
-#define REGULAR P1S  // G41
-#define KNEE P1S     // G41
+#define REGULAR P1L  // G41
+#define KNEE P1L     // G41
 #include "InstinctNybbleESP.h"
 
 #elif defined BITTLE
 #ifdef ROBOT_ARM
 #define MODEL "Bittle R"
+#include "InstinctBittleESP_arm.h"
+#define REGULAR P1S
+#define KNEE P1S
 #else
 #define MODEL "Bittle X"
+#include "InstinctBittleESP.h"
+#define REGULAR P1L
+#define KNEE P1L
 #endif
 
 #define HEAD
 #define TAIL  // the robot arm's clip is assigned to the tail joint
 #define LL_LEG
 
-#ifndef MINI
-#define REGULAR P1S
-#define KNEE P1S
-#else
-#define REGULAR P50
-#define KNEE P50
-#endif
-#ifdef ROBOT_ARM
-#include "InstinctBittleESP_arm.h"
-#else
-#include "InstinctBittleESP.h"
-#endif
+// #ifdef MINI
+// #define REGULAR P50
+// #define KNEE P50
+// #endif
 
 #elif defined CUB
 #define MODEL "DoF16"
@@ -254,6 +252,7 @@ double rate = 1.0 * MAX_READING / BASE_RANGE;
 enum ServoModel_t {
   G41 = 0,
   P1S,
+  P1L,
   P2K,
   P50
 };

--- a/src/configConstants.h
+++ b/src/configConstants.h
@@ -446,7 +446,7 @@ void configSetup() {
 #endif
 #ifndef AUTO_INIT
 #ifdef VOLTAGE
-    if (!lowBatteryQ)  // won't play sound if only powerd by USB. It avoid noise when developing codes
+    if (!lowBatteryQ)  // won't play sound if only powered by USB. It avoid noise when developing codes
 #endif
       playMelody(melodyInit, sizeof(melodyInit) / 2);
 #endif
@@ -474,7 +474,7 @@ void configSetup() {
   } else {
     resetIfVersionOlderThan(SoftwareVersion);
 #ifdef VOLTAGE
-    if (!lowBatteryQ)  // won't play sound if only powerd by USB. It avoid noise when developing codes
+    if (!lowBatteryQ)  // won't play sound if only powered by USB. It avoid noise when developing codes
 #endif
       playMelody(melodyNormalBoot, sizeof(melodyNormalBoot) / 2);
 #ifdef I2C_EEPROM_ADDRESS

--- a/src/espServo.h
+++ b/src/espServo.h
@@ -2,7 +2,7 @@
 #include "PetoiESP32Servo/ESP32Servo.h"
 //------------------angleRange  frequency  minPulse  maxPulse;
 ServoModel servoG41(180, SERVO_FREQ, 500, 2500);
-ServoModel servoP1S(270, SERVO_FREQ, 500, 2500);  // 1s/4 = 250ms 250ms/2500us=100Hz
+ServoModel servoP1S(290, SERVO_FREQ, 500, 2500);  // 1s/4 = 250ms 250ms/2500us=100Hz
 ServoModel servoP1L(270, SERVO_FREQ, 500, 2500);
 ServoModel servoP50(120, SERVO_FREQ, 900, 2100);
 #ifdef BiBoard2
@@ -46,6 +46,9 @@ void attachAllESPServos() {
         break;
       case P1S:
         modelObj[s] = &servoP1S;
+        break;
+      case P1L:
+        modelObj[s] = &servoP1L;
         break;
       case P2K:
         modelObj[s] = &servoP1L;
@@ -240,7 +243,7 @@ void servoFeedback(int8_t index = 16) {
         } else if (movedJoint[jointIdx])  //if it's not moved, its state will be decreased until set to false.
           movedJoint[jointIdx]--;
         currentAng[jointIdx] = readAngles[jointIdx];
-      } else
+      } else if (connectedFeedbackServo[jointIdx] < connectedCountDown)  // if the servo is confirmed to have feedback, it won't be deleted from the list
         connectedFeedbackServo[jointIdx] = max(int8_t(connectedFeedbackServo[jointIdx] - 1), int8_t(-connectedCountDown));
     }
   }
@@ -287,7 +290,7 @@ void readAllFeedbackFast()  // returns the pulse width in microseconds
   //if(!servo[s].attached())// adding this condition will cause servos to jig. why?
   for (int s = 0; s < 12; s++)
     servo[s].attach(PWM_pin[s], modelObj[s]);  // sometimes servo[s].attach() is true, but it still needs to be attached. why there's no conflict?
-  delay(3);                                   // it takes time to attach. potentially it can be avoided using the attached() check. but it doesn't work for now.
+  delay(3);                                    // it takes time to attach. potentially it can be avoided using the attached() check. but it doesn't work for now.
 
   for (int jointIdx = 0; jointIdx < DOF; jointIdx++) {
     if (jointIdx == 3) jointIdx = 8;

--- a/src/espServo.h
+++ b/src/espServo.h
@@ -247,13 +247,14 @@ void servoFeedback(int8_t index = 16) {
   if (infoPrinted)
     PTL();
 }
+
 bool servoFollow() {
   bool checkAll = true, moved = false;
   byte movedJointList[DOF];
   byte movedJointCount = 0;
   for (byte i = 0; i < PWM_NUM; i++) {  // decide if to check all servos.
     byte jointIdx = i < 4 ? i : i + 4;
-    if (movedJoint[jointIdx]) {  // only the previouslly moved joints will be checked.
+    if (movedJoint[jointIdx]) {  // only the previously moved joints will be checked.
       servoFeedback(jointIdx);
       checkAll = false;
       movedJointList[movedJointCount++] = jointIdx;

--- a/src/motion.h
+++ b/src/motion.h
@@ -495,7 +495,7 @@ void signalGenerator(int8_t resolution, int8_t speed, int8_t *pars, int8_t len, 
 }
 #define MAX_FRAME 125
 #define IDLE_LEARN 2000
-#define SMALL_DIFF 3
+#define SMALL_DIFF 7
 #define READY_COUNTDOWN 2
 int totalFrame = 0;
 int8_t learnData[11 * MAX_FRAME];

--- a/src/tools.h
+++ b/src/tools.h
@@ -1,32 +1,16 @@
-//abbreviations
-#define PT(s) Serial.print(s)  // abbreviate print commands
-#define PTD(s, format) Serial.print(s, format)
-#define PT_FMT(s, format) Serial.print(s, format)  // abbreviate print commands
-#define PTL(s) Serial.println(s)
-#define PTF(s) Serial.print(F(s))  //trade flash memory for dynamic memory with F() function
-#define PTLF(s) Serial.println(F(s))
-#define PTT(s, delimeter) \
-  { \
-    Serial.print(s); \
-    Serial.print(delimeter); \
-  }
-#define PTTL(s, delimeter) \
-  { \
-    Serial.print(s); \
-    Serial.println(delimeter); \
-  }
-#define PTH(head, value) \
-  { \
-    Serial.print(head); \
-    Serial.print('\t'); \
-    Serial.print(value); \
-  }
-#define PTHL(head, value) \
-  { \
-    Serial.print(head); \
-    Serial.print('\t'); \
-    Serial.println(value); \
-  }
+// Serial Print macro directive abbreviations
+  // Simple macro directives
+#define PT(s)             Serial.print(s)          // Serial print
+#define PTD(s, format)    Serial.print(s, format)  // Formatted serial print
+#define PTL(s)            Serial.println(s)        // Serial print plus newline
+#define PTF(s)            Serial.print(F(s))       // Serial print plus newline with trading flash memory for dynamic memory using F() function
+#define PTLF(s)           Serial.println(F(s))     // Serial print plus newline with trading flash memory for dynamic memory using F() function
+
+  // Composite macro directives
+#define PTT(s, delimeter)   PT(s);    PT(delimeter);               // Serial print with delimiter
+#define PTTL(s, delimeter)  PT(s);    PTL(delimeter);              // Serial print with delimiter plus newline
+#define PTH(head, value)    PT(head); PT('\t');       PT(value);   // Serial print with head, tab, value
+#define PTHL(head, value)   PT(head); PT('\t');       PTL(value);  // Serial print with head, tab, value plus newline
 
 char getUserInputChar(int waitTimeout = 0) {  //take only the first character, allow "no line ending", "newline", "carriage return", and "both NL & CR"
   long start = millis();

--- a/src/tools.h
+++ b/src/tools.h
@@ -211,7 +211,9 @@ void resetCmd() {
   // printCmd();
   lastToken = token;
   newCmdIdx = 0;
-  if (token != T_SKILL && token != T_SKILL_DATA && token != T_CALIBRATE && token != T_SERVO_FEEDBACK && token != T_SERVO_FOLLOW)
+  if (token != T_SKILL && token != T_SKILL_DATA && token != T_CALIBRATE 
+  //&& token != T_SERVO_FEEDBACK && token != T_SERVO_FOLLOW
+  )
     token = '\0';
   newCmd[0] = '\0';
   cmdLen = 0;

--- a/src/voice.h
+++ b/src/voice.h
@@ -26,9 +26,9 @@
 
 // #define VOICE_MODULE_SAMPLE
 String customizedCmdList[] = {
-// "xl",
-// "xp",
-// "F",
+// "fl",
+// "fr",
+// "fF",
 #ifdef BITTLE
 #ifdef ROBOT_ARM
   "kpickF",                          // pick front 捡起来


### PR DESCRIPTION
Here is a copy of the changes (from commit #4ab338f8 message)

In reaction.h:
• Simplified the logic for case T_SERVO_FEEDBACK: in reaction().
• Added explanatory comments.

In OpenCat.h:
• Grouped and added comments to Token (T_) and Character (C_) command list
• Grouped and added comments to "Q" booleans.

In tools.h
• Added comments and formatting for improved readability in print macros
• Used simple print macros to create composite single line print macros with good reading clarity while also providing IntelliSense info.
• Eliminated unused (and duplicate) print macro PT_FMT(s)

Notes
• Comments applied to the same line as the initialization of global variables provide proper IntelliSense info when using an IDE that supports that capability.
• Multi-line macro definitions are incompatible with this use of comments to provide IntelliSense info.