### PR TITLE
feat(on-demand IMU calibration): add taskCalibrateImuUsingCore0() oncore 0 and hook to case T_GYRO in reaction()

### DIFF
--- a/src/moduleManager.h
+++ b/src/moduleManager.h
@@ -425,7 +425,7 @@ void readSignal() {
                 IDLE_TIME
 #endif
       ;
-  else if (token != T_CALIBRATE && token != T_SERVO_FOLLOW && token != T_SERVO_FEEDBACK && current - idleTimer > 0) {
+  else if (token != T_SERVO_CALIBRATE && token != T_SERVO_FOLLOW && token != T_SERVO_FEEDBACK && current - idleTimer > 0) {
     if (moduleIndex == -1)  // no active module
       return;
 #ifdef CAMERA

--- a/src/motion.h
+++ b/src/motion.h
@@ -414,7 +414,7 @@ void autoCalibrate() {
   }
   saveCalib(servoCalib);
   tQueue->addTask(T_REST, "");
-  tQueue->addTask(T_CALIBRATE, "");
+  tQueue->addTask(T_SERVO_CALIBRATE, "");
   measureServoPin = 16;  // reattach the servos in the next reaction loop
 }
 

--- a/src/randomMind.h
+++ b/src/randomMind.h
@@ -50,7 +50,7 @@ void allRandom() {
 }
 String forbiddenSkills[] = { "ff", "bf", "rc", "rl", "jmp", "bk", "pd", "hlw", "calib", "dropped", "lifted", "ts", "ang", "zero", "zz", "lnd", "lpov" };
 void randomMind() {
-  if (token != T_CALIBRATE && token != T_REST && idleTimer && (millis() - idleTimer) > idleThreshold * 1000) {  //in idle state
+  if (token != T_SERVO_CALIBRATE && token != T_REST && idleTimer && (millis() - idleTimer) > idleThreshold * 1000) {  //in idle state
     if (millis() - randTimer > randomInterval) {                                                                //every randomInterval(ms) throw a dice
       randTimer = millis();
       int randomNum = esp_random() % randomBase;

--- a/src/tools.h
+++ b/src/tools.h
@@ -195,7 +195,7 @@ void resetCmd() {
   // printCmd();
   lastToken = token;
   newCmdIdx = 0;
-  if (token != T_SKILL && token != T_SKILL_DATA && token != T_CALIBRATE 
+  if (token != T_SKILL && token != T_SKILL_DATA && token != T_SERVO_CALIBRATE 
   //&& token != T_SERVO_FEEDBACK && token != T_SERVO_FOLLOW
   )
     token = '\0';


### PR DESCRIPTION
Add function taskCalibrateImuUsingCore0() [imu.h] which uses ulTaskNotifyTake() to await notification of an IMU calibration request.  In imuSetup() [imu.h], run that function as a perpetual task on core 0.  In reaction(), hook to case T_GYRO with C_GYRO_CALIBRATE or/and C1_GYRO_CALIBRATE_IMMEDIATELY (introduces a Character Command sequencing paradigm).  Use xTaskNotifyGive(taskCalibrateImuUsingCore0_handle) to give IMU calibration request notification from the core 1 thread to the core 0 thread.

This allows sending "gc" to get the original calibration behavior but without the need to reboot.  This also allows sending "gci" to get a new "calibrate immediately" behavior for true "on-demand" IMU calibration, again with no reboot.

In OpenCat.h, add documentation regarding Token and Character Commands (including the Character Command sequencing paradigm).  Rename T_CALIBRATE to T_SERVO_CALIBRATE to make its behavior more obvious now that we are calibrating the IMU.

Add a comment ***suggesting*** that C_LEARN be renamed to C_SERVO_FEEDBACK_LEARN and that C_REPLAY be renamed to C_SERVO_FEEDBACK_REPLAY since they appear to only be associated with token T_SERVO_FEEDBACK.